### PR TITLE
update lambda-wrapper dep so that node4.3 lambda can use callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "bluebird": "3.0.6",
     "chai": "3.2.0",
     "mocha": "2.2.5",
-    "lambda-wrapper": "0.0.4"
+    "lambda-wrapper": "0.0.6"
   }
 }


### PR DESCRIPTION
Fixes issue #9 - Support for New NodeJS 4.3.2 Lambda API