### PR TITLE
Replace backslash with foreslash in funcPath.

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,8 +239,8 @@ module.exports = function(S) { // Always pass in the ServerlessPlugin Class
         let funcFilePath = testFilePath(funcName);
         let projectPath = S.getProject().getRootPath();
         let funcFullPath = S.getProject().getFunction(funcName).getRootPath();
-        let funcPath = path.relative(projectPath, funcFullPath);
-
+        let funcPath = path.relative(projectPath, funcFullPath).replace(/\\/g, '/');
+        
         fs.exists(funcFilePath, function (exists) {
            if (exists) {
                return reject(new Error(`File ${funcFilePath} already exists`));


### PR DESCRIPTION
This caused a bit of nuisance as a Windows-based developer. It was not translating backslashes, so the path created for test files were not working.

Hopefully this is ok.