### PR TITLE
Fixed non-posix path separator and test entanglement issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Serverless Mocha Plugin
 
 A Serverless Plugin for the [Serverless Framework](http://www.serverless.com) which
-adds support for test driven development using [mocha](https://mochajs.org/) 
+adds support for test driven development using [mocha](https://mochajs.org/)
 
 **THIS PLUGIN REQUIRES SERVERLESS V0.5 OR HIGHER!**
 
@@ -57,10 +57,14 @@ If no function names are passed to mocha-run, all tests are run from the test/ d
 
 ## Release History
 
-* 2016/06/10 - v0.5.5 - Fix error message for mocha-create. 
+* 2016/05/17 - v0.5.8 - Fix entangled function tests.
+                      - Move wrapper.init into 'it' scope in generated mocha test code.
+* 2016/05/17 - v0.5.7 - Fix non-posix path separator in Windows.
+                      - Replace with forward slash in path.relative.
+* 2016/05/10 - v0.5.5 - Fix error message for mocha-create.
                       - Create tests with mocha-create without path in test name (as function create does)
 * 2016/05/09 - v0.5.3 - Set environment variables during mocha-run (by AniKo)
-                      - Add reporter options, return non-zero status for failures (by chouandy) 
+                      - Add reporter options, return non-zero status for failures (by chouandy)
 * 2016/04/09 - v0.5.0 - Initial version of module for serverless 0.5.*
 
 ## License

--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ module.exports = function(S) { // Always pass in the ServerlessPlugin Class
           let funcName = evt.options.paths;
           let mocha = new Mocha();
           //This could pose as an issue if several functions share a common ENV name but different values.
-          
+
           let stage = evt.options.stage || S.getProject().getAllStages()[0].name;
           let region = evt.options.region || S.getProject().getAllRegions(stage)[0].name;
 
@@ -206,13 +206,13 @@ module.exports = function(S) { // Always pass in the ServerlessPlugin Class
       var func = S.getProject().getFunction(funcName).toObjectPopulated(config);
       var envVars = func.environment;
       var fields = Object.keys(envVars);
-      
+
       for (var key in fields) {
         process.env[fields[key]] = envVars[fields[key]];
-      }  
+      }
     });
   }
-  
+
   // Create the test folder
   function createTestFolder() {
       return new BbPromise(function(resolve, reject) {
@@ -239,7 +239,7 @@ module.exports = function(S) { // Always pass in the ServerlessPlugin Class
         let funcFilePath = testFilePath(funcName);
         let projectPath = S.getProject().getRootPath();
         let funcFullPath = S.getProject().getFunction(funcName).getRootPath();
-        let funcPath = path.relative(projectPath, funcFullPath);
+        let funcPath = path.relative(projectPath, funcFullPath).replace(/\\/g, "/");
 
         fs.exists(funcFilePath, function (exists) {
            if (exists) {
@@ -294,10 +294,9 @@ const mochaPlugin = require('serverless-mocha-plugin');
 const wrapper     = mochaPlugin.lambdaWrapper;
 const expect      = mochaPlugin.chai.expect;
 
-wrapper.init(mod);
-
 describe('${funcName}', () => {
   it('implement tests here', (done) => {
+    wrapper.init(mod);
     wrapper.run({}, (err, response) => {
       done('no tests implemented');
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-mocha-plugin",
-  "version": "0.5.6",
+  "version": "0.5.8",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
Made two fixes:

0.5.7: On Windows the mocha-run failed due to 'path.relative' returning
non-posix separator, as a result 'require' path for handler.js became an
invalid string in the generated test code.

0.5.8: When running all tests with mocha-run (or mocha) 'wrapper.init'
in global scope caused subsequently run tests affecting the former
tests' scope. It appeared functional scope of the later test overriding
the former tests' scope, causing the former test to fail despite it
should have passed.