### PR TITLE
Wrapper.init should be done in before method

### DIFF
--- a/index.js
+++ b/index.js
@@ -294,9 +294,13 @@ const mochaPlugin = require('serverless-mocha-plugin');
 const wrapper     = mochaPlugin.lambdaWrapper;
 const expect      = mochaPlugin.chai.expect;
 
-wrapper.init(mod);
-
 describe('${funcName}', () => {
+  before(function (done) {
+    wrapper.init(mod);
+
+    done()
+  })
+  
   it('implement tests here', (done) => {
     wrapper.run({}, (err, response) => {
       done('no tests implemented');


### PR DESCRIPTION
The method should be executed in before method, otherwise it gets broken when we run multiple tests