### PR TITLE
Reset environment variables on every test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+# IDE
+.idea

--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ module.exports = function(S) { // Always pass in the ServerlessPlugin Class
             if (paths.length === 0) {
               return reject('No tests to run.');
             }
-            paths.forEach(function(func,idx) {
+            paths.forEach(function(func) {
               SetEnvVars(func, {
                 stage: stage,
                 region: region
@@ -178,14 +178,15 @@ module.exports = function(S) { // Always pass in the ServerlessPlugin Class
               process.on('exit', function () {
                 process.exit(failures);  // exit with non-zero status if there were failures
               });
-            }).on('suite', function(suite) {
+            }).on('suite', function(suite) { // reset environment variables
               let funcName = funcNameFromPath(suite.file);
               let func = S.getProject().getFunction(funcName);
-
-              SetEnvVars(func, {
-                stage: stage,
-                region: region
-              });
+              if (func) {
+                SetEnvVars(func, {
+                  stage: stage,
+                  region: region
+                });
+              }
             });
           }, function(error) {
 

--- a/index.js
+++ b/index.js
@@ -178,6 +178,14 @@ module.exports = function(S) { // Always pass in the ServerlessPlugin Class
               process.on('exit', function () {
                 process.exit(failures);  // exit with non-zero status if there were failures
               });
+            }).on('suite', function(suite) {
+              let funcName = funcNameFromPath(suite.file);
+              let func = S.getProject().getFunction(funcName);
+
+              SetEnvVars(func, {
+                stage: stage,
+                region: region
+              });
             });
           }, function(error) {
 
@@ -301,6 +309,12 @@ module.exports = function(S) { // Always pass in the ServerlessPlugin Class
   // Returns the path to a function's test file
   function testFilePath(funcName) {
       return path.join(testFolder, `${funcName.replace(/.*\//g, '')}.js`);
+  }
+
+  function funcNameFromPath(filePath) {
+    let data = path.parse(filePath)
+
+    return data.name
   }
 
   function newTestFile(funcName, funcPath) {


### PR DESCRIPTION
Currently, all environment variables are set before running tests what doesn't make them isolated between tests. Such behaviour may break tests or provide incorrect values.