### PR TITLE
Fix error creating test for existing functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = function(S) { // Always pass in the ServerlessPlugin Class
         context:       'function',
         contextAction: 'mocha-create',
         options:       [{
-          options:      'template',
+          option:       'template',
           shortcut:     'T',
           description:  'name of a template file used when creating test'
         }],
@@ -133,7 +133,7 @@ module.exports = function(S) { // Always pass in the ServerlessPlugin Class
         });
       }
 
-      return createTest(evt.options.paths[0]);
+      return createTest(evt.options.paths[0], evt.options.template || templateFilename);
     }
 
     _runAction(evt) {


### PR DESCRIPTION
Running `sls function mocha-create hello-world` was resulting in:

```
path.js:7
    throw new TypeError('Path must be a string. Received ' + inspect(path));
    ^

TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.join (path.js:1213:7)
    at /Users/mmoussa/Code/serverless-mocha-plugin/index.js:290:43
    at FSReqWrap.cb [as oncomplete] (fs.js:251:19)
```

This was happening due to the call to `createTest` in the `_createAction` not passing the 2nd parameter. This commit fixes that, as well as the issue where the `-T / --template` CLI option was not being used due to `options` instead of `option`.