### PR TITLE
Check to ensure environment is defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,11 +236,13 @@ class mochaPlugin {
 
   // SetEnvVars
   setEnvVars(funcName, options) {
-    utils.setEnv(this.serverless.environment.vars);
-    if (options.stage) {
-      utils.setEnv(this.serverless.environment.stages[options.stage].vars);
-      if (options.region) {
-        utils.setEnv(this.serverless.environment.stages[options.stage].regions[options.region].vars);
+    if (this.serverless.environment) {
+      utils.setEnv(this.serverless.environment.vars);
+      if (options.stage) {
+        utils.setEnv(this.serverless.environment.stages[options.stage].vars);
+        if (options.region) {
+          utils.setEnv(this.serverless.environment.stages[options.stage].regions[options.region].vars);
+        }
       }
     }
   }


### PR DESCRIPTION
I'm not sure if I have something weird in my serverless setup, but I can't get the tests to work because serverless.environment isn't defined.  This check makes everything OK.