### PR TITLE
Fix populate service

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ class mochaPlugin {
       .then((inited) => {
         myModule.serverless.environment = inited.environment;
         const vars = new myModule.serverless.classes.Variables(myModule.serverless);
-        vars.populateService();
+        vars.populateService(this.options);
         myModule.getFunctions(funcName)
           .then(utils.getTestFiles)
           .then((funcs) => {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-import": "^1.13.0",
     "eslint-plugin-jsx-a11y": "^2.1.0",
     "eslint-plugin-react": "^6.1.1",
-    "serverless": "^1.4.0"
+    "serverless": "^1.7.0"
   },
   "dependencies": {
     "aws-sdk": "^2.6.3",

--- a/test/integration-options.js
+++ b/test/integration-options.js
@@ -11,13 +11,13 @@ const serverless = new Serverless();
 serverless.init();
 const serverlessExec = path.join(serverless.config.serverlessPath, '..', 'bin', 'serverless');
 
-describe('integration', () => {
+describe('integration with stage option', () => {
   before(() => {
     // create temporary directory and copy test service there
     process.env.MOCHA_PLUGIN_TEST_DIR = path.join(__dirname);
     const tmpDir = testUtils.getTmpDirPath();
     fse.mkdirsSync(tmpDir);
-    fse.copySync(path.join(process.env.MOCHA_PLUGIN_TEST_DIR, 'test-service'), tmpDir);
+    fse.copySync(path.join(process.env.MOCHA_PLUGIN_TEST_DIR, 'test-service-options'), tmpDir);
     process.chdir(tmpDir);
   });
 
@@ -36,7 +36,7 @@ describe('integration', () => {
   });
 
   it('should create test for hello function', () => {
-    const test = execSync(`${serverlessExec} create test --function hello`);
+    const test = execSync(`${serverlessExec} create test --function hello --stage prod`);
     const result = new Buffer(test, 'base64').toString();
     expect(result).to.have.string(
       'serverless-mocha-plugin: created test/hello.js'
@@ -46,7 +46,7 @@ describe('integration', () => {
   it('should create function goodbye', () => {
     const test = execSync(
       `${serverlessExec}` +
-      ' create function --function goodbye --handler goodbye/index.handler'
+      ' create function --function goodbye --handler goodbye/index.handler --stage prod'
     );
     const result = new Buffer(test, 'base64').toString();
     expect(result).to.have.string(
@@ -66,7 +66,7 @@ describe('integration', () => {
       'require(\'serverless-mocha-plugin\')',
       'require(\'../.serverless_plugins/serverless-mocha-plugin/index.js\')'
     );
-    const test = execSync(`${serverlessExec} invoke test`);
+    const test = execSync(`${serverlessExec} invoke test --stage prod`);
     const result = new Buffer(test, 'base64').toString();
     expect(result).to.have.string(
       'goodbye\n    ✓ implement tests here'

--- a/test/integration.js
+++ b/test/integration.js
@@ -36,7 +36,7 @@ describe('integration', () => {
   });
 
   it('should create test for hello function', () => {
-    const test = execSync(`${serverlessExec} create test --function hello`);
+    const test = execSync(`${serverlessExec} create test --function hello --stage dev`);
     const result = new Buffer(test, 'base64').toString();
     expect(result).to.have.string(
       'serverless-mocha-plugin: created test/hello.js'
@@ -45,7 +45,7 @@ describe('integration', () => {
 
   it('should create function goodbye', () => {
     const test = execSync(
-      `${serverlessExec} create function --function goodbye --handler goodbye/index.handler`
+      `${serverlessExec} create function --function goodbye --handler goodbye/index.handler --stage dev`
     );
     const result = new Buffer(test, 'base64').toString();
     expect(result).to.have.string(

--- a/test/integration.js
+++ b/test/integration.js
@@ -45,7 +45,8 @@ describe('integration', () => {
 
   it('should create function goodbye', () => {
     const test = execSync(
-      `${serverlessExec} create function --function goodbye --handler goodbye/index.handler --stage dev`
+      `${serverlessExec}` +
+      ' create function --function goodbye --handler goodbye/index.handler --stage dev'
     );
     const result = new Buffer(test, 'base64').toString();
     expect(result).to.have.string(

--- a/test/test-service-options/.npmignore
+++ b/test/test-service-options/.npmignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/test/test-service-options/.serverless_plugins/serverless-mocha-plugin/index.js
+++ b/test/test-service-options/.serverless_plugins/serverless-mocha-plugin/index.js
@@ -1,0 +1,4 @@
+// Proxy
+const path = require('path');
+const mochaDir = path.join(process.env.MOCHA_PLUGIN_TEST_DIR, '../', 'index.js');
+module.exports = require(mochaDir);

--- a/test/test-service-options/handler.js
+++ b/test/test-service-options/handler.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports.hello = (event, context, callback) => {
+  const response = {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: 'Go Serverless v1.0! Your function executed successfully!',
+      input: event,
+    }),
+  };
+
+  callback(null, response);
+
+  // Use this code if you don't use the http event with the LAMBDA-PROXY integration
+  // callback(null, { message: 'Go Serverless v1.0! Your function executed successfully!', event });
+};

--- a/test/test-service-options/serverless.yml
+++ b/test/test-service-options/serverless.yml
@@ -20,6 +20,8 @@ service: mocha-test-suite
 provider:
   name: aws
   runtime: nodejs4.3
+  environment:
+    STAGE: ${opt:stage}-stage-test
 
 # you can overwrite defaults here
 #  stage: dev

--- a/test/test-service/serverless.yml
+++ b/test/test-service/serverless.yml
@@ -20,6 +20,8 @@ service: mocha-test-suite
 provider:
   name: aws
   runtime: nodejs4.3
+  environment:
+    STAGE: ${opt:stage}-stage-test
 
 # you can overwrite defaults here
 #  stage: dev


### PR DESCRIPTION
This PR fixes issue when options are passed from command line. For example `${opt:stage}` was failing when populating serverless object for tests. 

I also added test cases for this.

Closes #40 
