### PR TITLE
Support aws-nodejs6.10 runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
 - '4.3.2'
-- '6.9.0'
+- '6.10.0'
 script:
 - npm run lint
 - npm test

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const functionTemplateFile = path.join('templates', 'function-template.ejs');
 
 const validFunctionRuntimes = [
   'aws-nodejs4.3',
+  'aws-nodejs6.10',
 ];
 
 const humanReadableFunctionRuntimes = `${validFunctionRuntimes
@@ -356,7 +357,7 @@ class mochaPlugin {
 
         fse.writeFileSync(serverlessYmlFilePath, ymlEditor.dump());
 
-        if (runtime === 'aws-nodejs4.3') {
+        if (runtime === 'aws-nodejs4.3' || runtime === 'aws-nodejs6.10') {
           return this.createAWSNodeJSFuncFile(handler);
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-mocha-plugin",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/test-service-options/serverless.yml
+++ b/test/test-service-options/serverless.yml
@@ -19,7 +19,7 @@ service: mocha-test-suite
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   environment:
     STAGE: ${opt:stage}-stage-test
 

--- a/test/test-service/serverless.yml
+++ b/test/test-service/serverless.yml
@@ -19,7 +19,7 @@ service: mocha-test-suite
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
 
 # you can overwrite defaults here
 #  stage: dev


### PR DESCRIPTION
AWS now supports nodejs 6.10. This PR enables users who have specified runtime node 6.10 in their serverless.yml to generate functions and tests, otherwise it throws an error that it doesn't support the runtime. Updated Travis to the correct node version and test samples as well.