### PR TITLE
Wait until populateService is finished

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,8 +143,8 @@ class mochaPlugin {
       .then((inited) => {
         myModule.serverless.environment = inited.environment;
         const vars = new myModule.serverless.classes.Variables(myModule.serverless);
-        vars.populateService(this.options);
-        myModule.getFunctions(funcName)
+        vars.populateService(this.options)
+          .then(() => myModule.getFunctions(funcName))
           .then(utils.getTestFiles)
           .then((funcs) => {
             const funcNames = Object.keys(funcs);


### PR DESCRIPTION
`populateService` takes some time to complete, during this time environment variables will not be set. By waiting it will fix eventual consistency issues. This might fix https://github.com/SC5/serverless-mocha-plugin/issues/51